### PR TITLE
Add devcontainer configuration for CollabNote

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "CollabNote",
+    "dockerFile": "Dockerfile",
+    
+    // Forward ports
+    "forwardPorts": [3000],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "bradlc.vscode-tailwindcss",
+                "austenc.tailwind-docs"
+            ],
+            "settings": {
+                "editor.formatOnSave": true,
+                "editor.formatOnSaveMode": "file",
+                "[typescript]": {
+                    "editor.defaultFormatter": "esbenp.prettier-vscode"
+                }
+            }
+        }
+    }
+  }


### PR DESCRIPTION
This pull request adds a new development container configuration for the project, making it easier to set up a consistent development environment with recommended tools and settings.

Development environment setup:

* Added a `.devcontainer/devcontainer.json` file to define a dev container for the project, specifying the use of a `Dockerfile`, forwarding port 3000, and including recommended VS Code extensions and editor settings for formatting and Tailwind CSS support.